### PR TITLE
feat: Watch referenced secrets and trigger reconciliation on change

### DIFF
--- a/internal/controllers/cluster/controller.go
+++ b/internal/controllers/cluster/controller.go
@@ -961,5 +961,63 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			predicate.GenerationChangedPredicate{},
 			ctrlutils.ExactNamePredicate(r.ProviderName, ""),
 		))).
+		// watch source Secrets in provider namespace and reconcile all known Clusters if a referenced secret changes
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.mapSecretToRequests),
+			builder.WithPredicates(
+				predicate.NewPredicateFuncs(func(object client.Object) bool {
+					return object.GetNamespace() == r.ProviderNamespace
+				}),
+			)).
 		Complete(r)
+}
+
+// mapSecretToRequests checks if the changed secret is referenced in the DNSServiceConfig or PlatformService (external dns credentials or image pull secrets) and if so, returns a request for each known Cluster to trigger their reconciliation.
+func (r *ClusterReconciler) mapSecretToRequests(ctx context.Context, obj client.Object) []ctrl.Request {
+	log := logging.FromContextOrDiscard(ctx)
+	secret, ok := obj.(*corev1.Secret)
+	if !ok || secret.Namespace != r.ProviderNamespace {
+		return nil
+	}
+
+	config := &dnsv1alpha1.DNSServiceConfig{}
+	if err := r.PlatformCluster.Client().Get(ctx, types.NamespacedName{Name: r.ProviderName}, config); err != nil {
+		log.Error(err, "Failed to get DNSServiceConfig while checking secret relevance")
+		return nil
+	}
+
+	platformService := &providerv1alpha1.PlatformService{}
+	platformService.Name = r.ProviderName
+	if err := r.PlatformCluster.Client().Get(ctx, client.ObjectKeyFromObject(platformService), platformService); err != nil {
+		log.Error(err, "Failed to get PlatformService while checking secret relevance")
+		return nil
+	}
+
+	secretsSet := extractReferencedSecretNames(config, platformService)
+	if !secretsSet.Has(secret.Name) {
+		return nil
+	}
+
+	log.Info("Source secret changed, re-queuing known clusters", "secret", secret.Name)
+	return collections.ProjectSliceToSlice(r.listKnownClusters(), func(namespace types.NamespacedName) ctrl.Request {
+		return ctrl.Request{NamespacedName: namespace}
+	})
+}
+
+// extractReferencedSecretNames returns the set of secret names referenced by the given DNSServiceConfig and PlatformService.
+func extractReferencedSecretNames(config *dnsv1alpha1.DNSServiceConfig, platformService *providerv1alpha1.PlatformService) sets.Set[string] {
+	secretNames := sets.New[string]()
+	if config.Spec.SecretsToCopy != nil {
+		for _, secretRef := range config.Spec.SecretsToCopy.ToPlatformCluster {
+			secretNames.Insert(secretRef.Source.Name)
+		}
+		for _, secretRef := range config.Spec.SecretsToCopy.ToTargetCluster {
+			secretNames.Insert(secretRef.Source.Name)
+		}
+	}
+	if platformService != nil {
+		for _, pullSecret := range platformService.Spec.ImagePullSecrets {
+			secretNames.Insert(pullSecret.Name)
+		}
+	}
+	return secretNames
 }

--- a/internal/controllers/cluster/controller_test.go
+++ b/internal/controllers/cluster/controller_test.go
@@ -587,4 +587,81 @@ var _ = Describe("ClusterReconciler", func() {
 
 	})
 
+	It("should propagate source secret updates to platform and target clusters", func() {
+		env, fakeClientMapping := defaultTestSetup("testdata", "test-01")
+
+		c1 := &clustersv1alpha1.Cluster{}
+		Expect(env.Client().Get(env.Ctx, client.ObjectKey{Name: "cluster-01", Namespace: "foo"}, c1)).To(Succeed())
+		rr := env.ShouldReconcile(testutils.RequestFromObject(c1))
+		Expect(rr.RequeueAfter).To(BeNumerically(">", 0))
+		rr = env.ShouldReconcile(testutils.RequestFromObject(c1))
+		Expect(rr.RequeueAfter).To(BeZero())
+
+		expectedLabels := map[string]string{
+			openmcpconst.ManagedByLabel:      managedByValue,
+			openmcpconst.ManagedPurposeLabel: c1.Name,
+		}
+
+		// verify initial secret data on platform cluster
+		ss := &corev1.SecretList{}
+		Expect(env.Client().List(env.Ctx, ss, client.InNamespace(c1.Namespace), client.MatchingLabels(expectedLabels))).To(Succeed())
+		Expect(ss.Items).To(ContainElement(
+			MatchFields(IgnoreExtras, Fields{
+				"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+					"Name": Equal("my-auth-copy"),
+				}),
+				"Data": Equal(map[string][]byte{"key": []byte("value")}),
+			}),
+		))
+
+		// verify initial secret data on target cluster
+		Expect(fakeClientMapping["foo/cluster-01"].List(env.Ctx, ss, client.InNamespace(cluster.TargetClusterNamespace), client.MatchingLabels(expectedLabels))).To(Succeed())
+		Expect(ss.Items).To(ContainElement(
+			MatchFields(IgnoreExtras, Fields{
+				"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+					"Name": Equal("my-target-secret-copy"),
+				}),
+				"Data": Equal(map[string][]byte{"foobar": []byte("foobar")}),
+			}),
+		))
+
+		// update source secret "my-auth" (copied to platform cluster as "my-auth-copy")
+		srcSecret := &corev1.Secret{}
+		Expect(env.Client().Get(env.Ctx, client.ObjectKey{Name: "my-auth", Namespace: providerNamespace}, srcSecret)).To(Succeed())
+		srcSecret.Data = map[string][]byte{"key": []byte("rotated-value")}
+		Expect(env.Client().Update(env.Ctx, srcSecret)).To(Succeed())
+
+		// update source secret "my-target-secret" (copied to target cluster as "my-target-secret-copy")
+		srcTargetSecret := &corev1.Secret{}
+		Expect(env.Client().Get(env.Ctx, client.ObjectKey{Name: "my-target-secret", Namespace: providerNamespace}, srcTargetSecret)).To(Succeed())
+		srcTargetSecret.Data = map[string][]byte{"foobar": []byte("rotated-foobar")}
+		Expect(env.Client().Update(env.Ctx, srcTargetSecret)).To(Succeed())
+
+		// reconcile again to propagate the updated secrets
+		rr = env.ShouldReconcile(testutils.RequestFromObject(c1))
+		Expect(rr.RequeueAfter).To(BeZero())
+
+		// verify updated secret data on platform cluster
+		Expect(env.Client().List(env.Ctx, ss, client.InNamespace(c1.Namespace), client.MatchingLabels(expectedLabels))).To(Succeed())
+		Expect(ss.Items).To(ContainElement(
+			MatchFields(IgnoreExtras, Fields{
+				"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+					"Name": Equal("my-auth-copy"),
+				}),
+				"Data": Equal(map[string][]byte{"key": []byte("rotated-value")}),
+			}),
+		))
+
+		// verify updated secret data on target cluster
+		Expect(fakeClientMapping["foo/cluster-01"].List(env.Ctx, ss, client.InNamespace(cluster.TargetClusterNamespace), client.MatchingLabels(expectedLabels))).To(Succeed())
+		Expect(ss.Items).To(ContainElement(
+			MatchFields(IgnoreExtras, Fields{
+				"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+					"Name": Equal("my-target-secret-copy"),
+				}),
+				"Data": Equal(map[string][]byte{"foobar": []byte("rotated-foobar")}),
+			}),
+		))
+	})
+
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, when any of the secrets referenced in `DNSServiceConfig.spec.secretsToCopy` or `PlatformService.spec.imagePullSecrets` is updated, the changes are not propagated to the platform or target clusters until the next Cluster reconciliation is triggered. This could lead to stale credentials and errors.

This PR adds a watch to all referenced secrets and triggers a reconcile when they are updated.
**Which issue(s) this PR fixes**:
Fixes https://github.com/openmcp-project/backlog/issues/508

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The paltform-service-dns operator now watches imagePullSecrets and dns-services credentials and triggers a reconcile to update them at the platform/target cluster(s) if they are updated.
```
