### PR TITLE
Consolidates renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,7 +40,6 @@
       "semanticCommitType": "chore",
       "rebaseWhen": "auto",
       "minimumReleaseAge": "0 days",
-      "enabled": true,
       "matchPackageNames": [
         "/^github.com/openmcp-project//"
       ]

--- a/renovate.json
+++ b/renovate.json
@@ -3,39 +3,22 @@
   "git-submodules": {
     "enabled": true
   },
-  "minimumReleaseAge": "3 days",
+  "minimumReleaseAge": "0 days",
   "extends": [
     "config:recommended",
     "config:best-practices",
     "security:openssf-scorecard",
     "helpers:pinGitHubActionDigests",
-    ":rebaseStalePrs"
+    ":rebaseStalePrs",
+    ":enableVulnerabilityAlerts"
+  ],
+  "gitIgnoredAuthors": [
+    "github-actions[bot]@users.noreply.github.com"
   ],
   "postUpdateOptions": [
     "gomodTidy"
   ],
   "packageRules": [
-    {
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchDepNames": [
-        "go"
-      ],
-      "matchDepTypes": [
-        "golang"
-      ],
-      "rangeStrategy": "bump"
-    },
-    {
-      "matchPackageNames": [
-        "github.com/openmcp-project/*"
-      ],
-      "description": "Update all components from openmcp-project immediately",
-      "rebaseWhen": "auto",
-      "minimumReleaseAge": "0 days",
-      "enabled": true
-    },
     {
       "description": "Group openmcp-project/build submodule and workflow updates",
       "matchDepNames": [
@@ -43,6 +26,24 @@
         "openmcp-project/build"
       ],
       "groupName": "openmcp-project/build"
+    },
+    {
+      "description": "Update and automerge all components from openmcp-project immediately in one singe PR",
+      "matchManagers": [
+        "gomod"
+      ],
+      "groupName": "openmcp-project Go dependencies",
+      "groupSlug": "openmcp-go-deps",
+      "automerge": true,
+      "automergeType": "pr",
+      "prPriority": 10,
+      "semanticCommitType": "chore",
+      "rebaseWhen": "auto",
+      "minimumReleaseAge": "0 days",
+      "enabled": true,
+      "matchPackageNames": [
+        "/^github.com/openmcp-project//"
+      ]
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

like in https://github.com/openmcp-project/cluster-provider-gardener/blob/main/renovate.json

which then updates all openmcp-project dependencies in one PR https://github.com/openmcp-project/cluster-provider-gardener/pull/266

instead of multiple PRs which needs rebase after every merge
- https://github.com/openmcp-project/platform-service-dns/pull/112
- https://github.com/openmcp-project/platform-service-dns/pull/113

minimumReleaseAge removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency

```
