### PR TITLE
chore(deps): renovate org-preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,32 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>openmcp-project/.github:renovate-config",
+    ":enableVulnerabilityAlerts"
+  ],
   "git-submodules": {
     "enabled": true
   },
   "minimumReleaseAge": "0 days",
-  "extends": [
-    "config:recommended",
-    "config:best-practices",
-    "security:openssf-scorecard",
-    "helpers:pinGitHubActionDigests",
-    ":rebaseStalePrs",
-    ":enableVulnerabilityAlerts"
-  ],
   "gitIgnoredAuthors": [
     "github-actions[bot]@users.noreply.github.com"
   ],
-  "postUpdateOptions": [
-    "gomodTidy"
-  ],
   "packageRules": [
-    {
-      "description": "Group openmcp-project/build submodule and workflow updates",
-      "matchDepNames": [
-        "hack/common",
-        "openmcp-project/build"
-      ],
-      "groupName": "openmcp-project/build"
-    },
     {
       "description": "Update and automerge all components from openmcp-project immediately in one singe PR",
       "matchManagers": [


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves `renovate.json` to `.github/renovate.json` and references the new org-level preset
- `extends`: recommended + best-practices + openssf-scorecard + pinGitHubActionDigests + rebaseStalePrs
- `postUpdateOptions`: gomodTidy
- golang `rangeStrategy: bump` rule
- `openmcp-project/build` group rule
- `openmcp-project` Go dependencies grouped into one PR

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other dependency

```